### PR TITLE
Whitelist incoming requests.

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ const ORIGIN_WHITELIST = [
   'status.taskcluster.net'
 ];
 
-const NODE_ENV = process.env.NODE_ENV || 'developemnt';
+const NODE_ENV = process.env.NODE_ENV || 'development';
 
 // Schema for json request and http headers
 const RequestSchema = {

--- a/server.js
+++ b/server.js
@@ -9,6 +9,11 @@ const sslify = require('express-sslify');
 const debug = require('debug')('cors-proxy:server');
 const morganDebug = require('morgan-debug');
 
+const ORIGIN_WHITELIST = [
+  'tools.taskcluster.net',
+  'status.taskcluster.net'
+];
+
 const NODE_ENV = process.env.NODE_ENV || 'developemnt';
 
 // Schema for json request and http headers
@@ -33,14 +38,17 @@ const PreflightSchema = {
   }
 };
 
+export function checkDomain(host) {
+  return ORIGIN_WHITELIST.some(domain => domain == host);
+}
+
 function setupCORS(req, res) {
   if (NODE_ENV === 'production') {
     const origin = req.headers['Origin'];
     const host = urlParse(origin).host;
 
-    // Check if we are under taskcluster domain
-    if (!/[a-zA-z0-9_.]\.taskcluster\.net/i.test(host)) {
-      debug(`${origin} is not a Taskcluster domain`);
+    if (!checkDomain(host)) {
+      debug(`${origin} is not a valid Taskcluster domain`);
       return;
     }
 
@@ -133,7 +141,7 @@ function requestHandler(req, res) {
   request.end();
 }
 
-export default function proxyServer(port = 80) {
+export function proxyServer(port = 80) {
   return new Promise(async function(accept, reject) {
     const app = express();
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,5 +1,5 @@
 const mocha = require('mocha');
-const proxyServer = require('../server');
+const proxyServer = require('../server').proxyServer;
 const fakeWebServer = require('./fake_webserver');
 const debug = require('debug')('cors-proxy:mocha');
 

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -3,6 +3,7 @@ suite('server test', async function() {
   const assert = require('assert');
   const helper = require('./helper');
   const Entities = require('html-entities').AllHtmlEntities;
+  const checkDomain = require('../server').checkDomain;
 
   const entities = new Entities();
 
@@ -37,6 +38,12 @@ suite('server test', async function() {
       });
     }).then(body => entities.decode(body));
   }
+
+  test('check domain', function() {
+    assert.equal(checkDomain('tools.taskcluster.net'), true);
+    assert.equal(checkDomain('status.taskcluster.net'), true);
+    assert.equal(checkDomain('public-artifacts.taskcluster.net'), false);
+  });
 
   test('no url supplied', async function() {
     let res = await makeRequest({port: 80});


### PR DESCRIPTION
We now provide a white list of domains that can make requests to the
cors-proxy. This is necessary because even content inside taskcluster
domain can have arbitrary javascript code, like public-artifact.tc.net.
